### PR TITLE
Update to version 0.1.1 and adjust output folder to `target/bq2dbt` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This script is used to generate the explicit SQL file (explicit = don't use sele
   - with primary key if any
   - with correct handling of the ARRAY/STRUCT types
 
-Ouput is generated in the `./output/{{project}}/{dataset}` folder from where you run the script.
+Ouput is generated in the `./target/bq2dbt/{{project}}/{dataset}` folder from where you run the script. You can change it with option `--output`.
 
 ## Disclaimer
 
@@ -40,13 +40,13 @@ Example:
 
 # CLI arguments
 
-| Option          | Description                                      |
-|-----------------|--------------------------------------------------|
-| `-l`, `--lower` | Output type names as lowercase in YAML file      |
-| `--snake`       | Convert field names to snake_case (SQL and YAML) |
-| `--prefix`      | Prefix to add to columns names (default: None)   |
-| `--suffix`      | Suffix to add to column names (default: None)    |
-
+| Option          | Description                                              |
+|-----------------|----------------------------------------------------------|
+| `-l`, `--lower` | Output type names as lowercase in YAML file              |
+| `--snake`       | Convert field names to snake_case (SQL and YAML)         |
+| `--prefix`      | Prefix to add to columns names (default: None)           |
+| `--suffix`      | Suffix to add to column names (default: None)            |
+| `--output`      | Destination folder for scripts. By default target/bq2dbt |
 
 # TODO
 

--- a/bq2dbt/bq2dbt.py
+++ b/bq2dbt/bq2dbt.py
@@ -5,11 +5,11 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 General Public License for more details.
 """
 
-import yaml
 import argparse
-import os
 import logging
+import os
 import re
+import yaml
 
 from google.cloud import bigquery
 
@@ -36,19 +36,25 @@ def convert_to_snake_case(input_string: str) -> str:
 
 
 def bq2dbt():
+    """
+    Main function. Parse arguments and do the job
+    """
     parser = argparse.ArgumentParser(description="Generate YAML and SQL output for a BigQuery table.")
     parser.add_argument("table_id", help="Complete BigQuery table ID (project.dataset.table)")
     parser.add_argument("-l", "--lower", action="store_true", help="Lowercase type names in YAML file")
     parser.add_argument("--snake", action="store_true", help="Convert field names to snake_case")
     parser.add_argument("--prefix", help="Prefix to add to columns names", default=None)
     parser.add_argument("--suffix", help="Suffix to add to column names", default=None)
+    parser.add_argument("--output", help="Output folder of scripts. By default 'target/bq2dbt'.", default='target/bq2dbt')
     args = parser.parse_args()
 
     project_id, dataset_id, table_name = args.table_id.split(".")
     prefix = args.prefix
     suffix = args.suffix
 
-    logger.info(f"Starting generation of YAML and SQL for table {args.table_id}...")
+    output_folder = args.output
+
+    logger.info("Starting generation of YAML and SQL for table %s...", args.table_id)
 
     client = bigquery.Client(project=project_id)
 
@@ -146,15 +152,15 @@ def bq2dbt():
         `{project_id}.{dataset_id}.{table_name}`  -- Don't leave this in your DBT Statement
     """
 
-    output_path = f"./output/{project_id}/{dataset_id}"
+    output_path = f"./{output_folder}/{project_id}/{dataset_id}"
     os.makedirs(output_path, exist_ok=True)
 
-    logger.info(f"Generating YAML and SQL files to path: {output_path}")
+    logger.info("Generating YAML and SQL files to path: %s", output_path)
 
-    with open(f"{output_path}/{table_name}.yaml", "w") as yaml_file:
+    with open(f"{output_path}/{table_name}.yaml", "w", encoding="utf-8") as yaml_file:
         yaml_file.write(yaml_output)
 
-    with open(f"{output_path}/{table_name}.sql", "w") as sql_file:
+    with open(f"{output_path}/{table_name}.sql", "w", encoding="utf-8") as sql_file:
         sql_file.write(sql_output.strip())
 
     logger.info("Operation complete")

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-setup(name='bq2dbt', version='0.1.0',
+setup(name='bq2dbt', version='0.1.1',
       description='Read a table/view from BigQuery and generates model definition YAML file'
                   'and basic select query with explicit columns list',
       url='https://github.com/H-Max/bq2dbt',


### PR DESCRIPTION
Fix some pylint issues and add output option
target/bq2dbt is now the default output folder